### PR TITLE
Descoping BERT for mobile

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,6 @@ Take a look at the in progress projects to see what it's like to work on a proje
 * [`arbitrary_image_stylization` by Magenta](https://github.com/magenta/magenta/tree/f3b66aa1354cd933f0e9757a567cc9a3d2d03297/magenta/models/arbitrary_image_stylization) - art generation. Colab Notebooks demonstrating TFLite model conversion process along with inference in Python are [available on TF Hub](https://tfhub.dev/sayakpaul/lite-model/arbitrary-image-stylization-inceptionv3/dr/predict/1). The TFLite models can be downloaded from the same link. 
 * Enhanced super res GAN - [project repo](https://github.com/margaretmz/esrgan-e2e-tflite-tutorial).
 * Speech Command - [overview](overviews/speech_command.md).
-* BERT for Mobile - [project repo](https://github.com/sayakpaul/BERT-for-Mobile).
 
 ## End-to-end tutorials (completed)
 


### PR DESCRIPTION
Although the majority of "BERT for Mobile" is complete it appears that there are still some unclarities in the model conversions for MobileBERT and ALBERT i.e. the converted models aren't able to produce expected results (drop from original 90% to 49%). Note that when a MobileBERT model is fine-tuned using the Model Maker tool the performance is greatly retained. This is indeed weird actually. 

Unfortunately, the TFLite team currently has other competing priorities so they may not be able to take a look at this issue. So, with these unclarities, I don't feel comfortable publishing the blog post. I Will update accordingly when things start to move in the right direction. 